### PR TITLE
Improve syntax error reporting

### DIFF
--- a/terraform_validate/fixtures/invalid_syntax/1.tf
+++ b/terraform_validate/fixtures/invalid_syntax/1.tf
@@ -1,0 +1,3 @@
+resource "foo" "bar" {
+    array = ["1","2","3"
+}

--- a/terraform_validate/functional_test.py
+++ b/terraform_validate/functional_test.py
@@ -77,6 +77,9 @@ class TestValidatorFunctional(unittest.TestCase):
         validator = t.Validator(os.path.join(self.path, "fixtures/nested_resource"))
         validator.assert_nested_resource_property_value_equals(['aws_instance','aws_elb'],'tags', 'value', 1)
 
+    def test_invalid_terraform_syntax(self):
+        self.assertRaises(t.TerraformSyntaxException, t.Validator,os.path.join(self.path, "fixtures/invalid_syntax"))
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorFunctional)
     unittest.TextTestRunner(verbosity=0).run(suite)

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -25,7 +25,6 @@ class Validator:
                         try:
                             hcl.loads(new_terraform)
                         except ValueError as e:
-                            print('Error in Terraform syntax: {0}'.format(e))
                             raise TerraformSyntaxException("Invalid terraform configuration in {0}\n{1}".format(os.path.join(directory,file),e))
                         terraform_string += new_terraform
         terraform = hcl.loads(terraform_string)

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -2,6 +2,9 @@ import hcl
 import os
 import re
 
+class TerraformSyntaxException(Exception):
+    pass
+
 class TerraformVariableException(Exception):
     pass
 
@@ -18,8 +21,13 @@ class Validator:
             for file in files:
                 if (file.endswith(".tf")):
                     with open(os.path.join(directory, file)) as fp:
-                        terraform_string += fp.read()
-
+                        new_terraform = fp.read()
+                        try:
+                            hcl.loads(new_terraform)
+                        except ValueError,e:
+                            print 'Error in Terraform syntax: {0}'.format(e)
+                            raise TerraformSyntaxException("Invalid terraform configuration in {0}\n{1}".format(os.path.join(directory,file),e))
+                        terraform_string += new_terraform
         terraform = hcl.loads(terraform_string)
         return terraform
 

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -24,7 +24,7 @@ class Validator:
                         new_terraform = fp.read()
                         try:
                             hcl.loads(new_terraform)
-                        except ValueError,e:
+                        except ValueError as e:
                             print 'Error in Terraform syntax: {0}'.format(e)
                             raise TerraformSyntaxException("Invalid terraform configuration in {0}\n{1}".format(os.path.join(directory,file),e))
                         terraform_string += new_terraform

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -25,7 +25,7 @@ class Validator:
                         try:
                             hcl.loads(new_terraform)
                         except ValueError as e:
-                            print 'Error in Terraform syntax: {0}'.format(e)
+                            print('Error in Terraform syntax: {0}'.format(e))
                             raise TerraformSyntaxException("Invalid terraform configuration in {0}\n{1}".format(os.path.join(directory,file),e))
                         terraform_string += new_terraform
         terraform = hcl.loads(terraform_string)


### PR DESCRIPTION
If an invalid terraform config file is encountered, print the parser error and let the user know which file it's tripped up on.