### PR TITLE
Multiple variable substitution

### DIFF
--- a/terraform_validate/fixtures/multiple_variables/1.tf
+++ b/terraform_validate/fixtures/multiple_variables/1.tf
@@ -6,7 +6,6 @@ variable "test_variable2" {
     default = "2"
 }
 
-
 resource "aws_instance" "foo" {
     value = "${var.test_variable}${var.test_variable2}"
 }

--- a/terraform_validate/fixtures/multiple_variables/1.tf
+++ b/terraform_validate/fixtures/multiple_variables/1.tf
@@ -1,0 +1,12 @@
+variable "test_variable" {
+    default = "1"
+}
+
+variable "test_variable2" {
+    default = "2"
+}
+
+
+resource "aws_instance" "foo" {
+    value = "${var.test_variable}${var.test_variable2}"
+}

--- a/terraform_validate/functional_test.py
+++ b/terraform_validate/functional_test.py
@@ -80,6 +80,10 @@ class TestValidatorFunctional(unittest.TestCase):
     def test_invalid_terraform_syntax(self):
         self.assertRaises(t.TerraformSyntaxException, t.Validator,os.path.join(self.path, "fixtures/invalid_syntax"))
 
+    def test_invalid_terraform_syntax(self):
+        validator = t.Validator(os.path.join(self.path, "fixtures/multiple_variables"))
+        validator.assert_resource_property_value_equals('aws_instance','value',12)
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorFunctional)
     unittest.TextTestRunner(verbosity=0).run(suite)

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -62,6 +62,9 @@ class Validator:
                 out[property] = properties[property]
         return out
 
+    def list_terraform_variables_in_string(self, string):
+        return []
+
     def get_terraform_property_value(self, name,values):
         if name not in values:
             return None

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -62,15 +62,19 @@ class Validator:
                 out[property] = properties[property]
         return out
 
+    def substitute_variable_values_in_string(self, s):
+        for variable in self.list_terraform_variables_in_string(s):
+            s = s.replace('${var.'+variable+'}',self.get_terraform_variable_value(variable))
+        return s
+
     def list_terraform_variables_in_string(self, s):
-        return re.findall('\${var.(\w+)}',s)
+        return re.findall('\${var.(\w+)}',str(s))
 
     def get_terraform_property_value(self, name,values):
         if name not in values:
             return None
         for value in values:
-            if self.is_terraform_variable(values[value]):
-                values[value] = self.get_terraform_variable_value(self.get_terraform_variable_name(values[value]))
+            values[value] = self.substitute_variable_values_in_string(values[value])
         return values[name]
 
     def convert_to_list(self, nested_resources):

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -62,8 +62,8 @@ class Validator:
                 out[property] = properties[property]
         return out
 
-    def list_terraform_variables_in_string(self, string):
-        return []
+    def list_terraform_variables_in_string(self, s):
+        return re.findall('\${var.(\w+)}',s)
 
     def get_terraform_property_value(self, name,values):
         if name not in values:

--- a/terraform_validate/unit_test.py
+++ b/terraform_validate/unit_test.py
@@ -25,6 +25,11 @@ class TestValidatorUnitHelper(unittest.TestCase):
         a = v.matches_regex_pattern('abc_123', '^abc_321$')
         self.assertFalse(a)
 
+    def test_can_find_one_variable_in_string(self):
+        v = t.Validator()
+        a = v.list_terraform_variables_in_string("${var.a}${var.b}")
+        self.assertEqual(a,["a","b"])
+
     if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorUnitHelper)
         unittest.TextTestRunner(verbosity=0).run(suite)

--- a/terraform_validate/unit_test.py
+++ b/terraform_validate/unit_test.py
@@ -25,10 +25,25 @@ class TestValidatorUnitHelper(unittest.TestCase):
         a = v.matches_regex_pattern('abc_123', '^abc_321$')
         self.assertFalse(a)
 
+    def test_can_handle_no_variables_in_string(self):
+        v = t.Validator()
+        a = v.list_terraform_variables_in_string("wibble")
+        self.assertEqual(a,[])
+
     def test_can_find_one_variable_in_string(self):
         v = t.Validator()
-        a = v.list_terraform_variables_in_string("${var.a}${var.b}")
-        self.assertEqual(a,["a","b"])
+        a = v.list_terraform_variables_in_string("${var.abc}")
+        self.assertEqual(a,["abc"])
+
+    def test_can_find_multiple_variables_in_string(self):
+        v = t.Validator()
+        a = v.list_terraform_variables_in_string("${var.abc}${var.def}")
+        self.assertEqual(a,["abc","def"])
+
+    def test_can_find_multiple_variables_in_complex_string(self):
+        v = t.Validator()
+        a = v.list_terraform_variables_in_string("a${var.abc}b${var.def}c")
+        self.assertEqual(a,["abc","def"])
 
     if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorUnitHelper)

--- a/terraform_validate/unit_test.py
+++ b/terraform_validate/unit_test.py
@@ -45,6 +45,11 @@ class TestValidatorUnitHelper(unittest.TestCase):
         a = v.list_terraform_variables_in_string("a${var.abc}b${var.def}c")
         self.assertEqual(a,["abc","def"])
 
+    def test_handle_finding_variables_in_non_string_object(self):
+        v = t.Validator()
+        a = v.list_terraform_variables_in_string(1)
+        self.assertEqual(a, [])
+
     if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorUnitHelper)
         unittest.TextTestRunner(verbosity=0).run(suite)


### PR DESCRIPTION
Blocks like this will no longer cause a TerraformVariableException

```
resource "aws_instance" "foo" {
    value = "${var.test_variable}${var.test_variable2}"
}
```