### PR TITLE
Give the user the option to disable expanding of variables when the default value exists

### DIFF
--- a/terraform_validate/fixtures/variable_expansion/1.tf
+++ b/terraform_validate/fixtures/variable_expansion/1.tf
@@ -1,0 +1,7 @@
+variable "bar" {
+    default = "1"
+}
+
+resource "aws_instance" "foo" {
+    value = "${var.bar}"
+}

--- a/terraform_validate/functional_test.py
+++ b/terraform_validate/functional_test.py
@@ -88,6 +88,11 @@ class TestValidatorFunctional(unittest.TestCase):
         validator = t.Validator(os.path.join(self.path, "fixtures/multiple_variables"))
         validator.assert_nested_resource_property_value_equals('aws_instance','value_block','value',21)
 
+    def test_variable_expansion(self):
+        validator = t.Validator(os.path.join(self.path, "fixtures/variable_expansion"))
+        validator.disable_variable_expansion()
+        validator.assert_resource_property_value_equals('aws_instance','value','${var.bar}')
+
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestValidatorFunctional)
     unittest.TextTestRunner(verbosity=0).run(suite)

--- a/terraform_validate/terraform_validate.py
+++ b/terraform_validate/terraform_validate.py
@@ -11,8 +11,12 @@ class TerraformVariableException(Exception):
 class Validator:
 
     def __init__(self,path=None):
+        self.variable_expand = True
         if path is not None:
             self.terraform_config = self.parse_terraform_directory(path)
+
+    def disable_variable_expansion(self):
+        self.variable_expand = False
 
     def parse_terraform_directory(self,path):
 
@@ -77,7 +81,8 @@ class Validator:
         if name not in values:
             return None
         for value in values:
-            values[value] = self.substitute_variable_values_in_string(values[value])
+            if self.variable_expand:
+                values[value] = self.substitute_variable_values_in_string(values[value])
         return values[name]
 
     def convert_to_list(self, nested_resources):


### PR DESCRIPTION
This allows the user to call .disable_variable_expansion() on the validator object, to check the value of a property without referring to any of the variables

```
resource "foo" "bar" {
   bizz = ${var.buzz}
}

var "buzz" {
    default = "1"
}

Before: terraform_config thinks that bizz = 1
After (default): terraform_config thinks that bizz = 1
After (with .disable_variable_expansion): terraform_config thinks that bizz = "${var.buzz}"}
```